### PR TITLE
Add CIFAR10 & 100 datasets. Allow model construction to be dataset specific.

### DIFF
--- a/networkAlignmentAnalysis/datasets.py
+++ b/networkAlignmentAnalysis/datasets.py
@@ -11,12 +11,17 @@ from .models.base import AlignmentNetwork
 
 REQUIRED_PROPERTIES = ['dataset_path', 'dataset_constructor', 'loss_function']
 
-def default_loader_parameters(batch_size=1024):
+def default_loader_parameters(batch_size=1024, num_workers=2, shuffle=True, pin_memory=True, persistent_workers=True):
+    """
+    contains the default dataloader parameters with the option of updating them
+    using key word argument
+    """
     default_parameters = dict(
         batch_size=batch_size,
-        num_workers=multiprocessing.cpu_count()-2, # use the computer without stealing all resources
-        shuffle=True,
-        pin_memory=True,
+        num_workers=num_workers, # usually 2 workers is appropriate for swapping loading during batch processing
+        shuffle=shuffle,
+        pin_memory=pin_memory,
+        persistent_workers=persistent_workers,
     )
     return default_parameters
 
@@ -182,7 +187,7 @@ class CIFAR10(DataSet):
         self.dataset_path = files.dataset_path("CIFAR10")
         self.dataset_constructor = torchvision.datasets.CIFAR10
         self.loss_function = nn.CrossEntropyLoss()
-        self.dist_params = dict(mean=0.1307, std=0.3081)
+        self.dist_params = dict(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 
     def make_transform(self, resize=None, flatten=False):
         """
@@ -224,7 +229,7 @@ class CIFAR100(CIFAR10):
         self.dataset_path = files.dataset_path("CIFAR100")
         self.dataset_constructor = torchvision.datasets.CIFAR100
         self.loss_function = nn.CrossEntropyLoss()
-        self.dist_params = dict(mean=0.1307, std=0.3081)
+        self.dist_params = dict(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 
 
 DATASET_REGISTRY = {

--- a/networkAlignmentAnalysis/datasets.py
+++ b/networkAlignmentAnalysis/datasets.py
@@ -200,7 +200,7 @@ class CIFAR10(DataSet):
             # Convert PIL Image to PyTorch Tensor
             transforms.ToTensor(), 
             # Normalize inputs to canonical distribution
-            transforms.Normalize((self.dist_params['mean'],), (self.dist_params['std'],)), 
+            transforms.Normalize((self.dist_params['mean']), (self.dist_params['std'])), 
             ]
         
         # extra transforms depending on network

--- a/networkAlignmentAnalysis/experiments/alignment_stats.py
+++ b/networkAlignmentAnalysis/experiments/alignment_stats.py
@@ -121,12 +121,7 @@ class AlignmentStatistics(Experiment):
         else:
             raise ValueError(f"optimizer ({self.args.optimizer}) not recognized")
         
-        # get network
-        model_kwargs = {}
-        if self.args.network == 'AlexNet' and self.args.dataset == 'MNIST':
-            model_kwargs['num_classes'] = 10
-
-        nets = [get_model(self.args.network, build=True, dropout=self.args.default_dropout, **model_kwargs)
+        nets = [get_model(self.args.network, build=True, dataset=self.args.dataset, dropout=self.args.default_dropout)
                 for _ in range(self.args.replicates)]
         nets = [net.to(self.device) for net in nets]
         optimizers = [optim(net.parameters(), lr=self.args.default_lr, weight_decay=self.args.default_wd)

--- a/networkAlignmentAnalysis/files.py
+++ b/networkAlignmentAnalysis/files.py
@@ -28,3 +28,5 @@ def dataset_path(dataset):
     """path to specific stored datasets (they all have different requirements)"""
     if dataset=='MNIST':
         return data_path()
+    elif dataset=='CIFAR10' or dataset=='CIFAR100':
+        return data_path()

--- a/networkAlignmentAnalysis/models/registry.py
+++ b/networkAlignmentAnalysis/models/registry.py
@@ -6,16 +6,72 @@ MODEL_REGISTRY = {
     'AlexNet': models.AlexNet,
 }
 
-def get_model(model_name, build=False, **kwargs):
+DATASET_ARGUMENTS = {
+    'MLP': {
+        'MNIST': dict(input_dim=784, output_dim=10),
+        'CIFAR10': dict(input_dim=3072, output_dim=10),
+        'CIFAR100': dict(input_dim=3072, output_dim=100),
+    },
+    'CNN2P2': {
+        'MNIST': dict(in_channels=1, output_dim=10),
+        'CIFAR10': dict(in_channels=3, output_dim=10),
+        'CIFAR100': dict(in_channels=3, output_dim=100),
+    },
+    'AlexNet': {
+        'MNIST': dict(num_classes=10),
+        'CIFAR10': dict(num_classes=10),
+        'CIFAR100': dict(num_classes=100),
+    },
+}
+
+def get_model_parameters(model_name, dataset):
+    """
+    lookup model parameters by dataset
+
+    returns a dictionary containing the keyword arguments to pass to the model constructor
+    for a particular model/dataset combination.
+    """
+    if model_name not in DATASET_ARGUMENTS:
+        raise ValueError(f"Model ({model_name}) is not in DATASET_ARGUMENTS lookup dictionary.")
+    if dataset not in DATASET_ARGUMENTS[model_name]:
+        raise ValueError(f"Dataset ({dataset}) is not in the DATASET_ARGUMENTS lookup for model ({model_name})")
+    
+    # get dataset specific arguments
+    return DATASET_ARGUMENTS[model_name][dataset]
+
+
+def get_model(model_name, build=False, dataset=None, **kwargs):
     """
     lookup model constructor from model registry by name
 
     if build=True, uses kwargs to build model and returns a model object
     otherwise just returns the constructor
+
+    if build=True and dataset is not None, will look up dataset specific 
+    keyword arguments from the DATASET_ARGUMENTS dictionary using the 
+    model_name and dataset as a lookup and add those to any kwargs used
+    for building the model
     """
     if model_name not in MODEL_REGISTRY:
         raise ValueError(f"Model ({model_name}) is not in MODEL_REGISTRY")
     model = MODEL_REGISTRY[model_name]
     if build:
+        if dataset is not None:
+            if model_name not in DATASET_ARGUMENTS:
+                raise ValueError(f"Model ({model_name}) is not in DATASET_ARGUMENTS lookup dictionary.")
+            if dataset not in DATASET_ARGUMENTS[model_name]:
+                raise ValueError(f"Dataset ({dataset}) is not in the DATASET_ARGUMENTS lookup for model ({model_name})")
+            # get dataset specific arguments
+            dataset_specific_arguments = DATASET_ARGUMENTS[model_name][dataset]
+
+            # for every dataset specific argument, if the key isn't provided in kwargs, 
+            # then update it using the dataset_specific_arguments
+            for key, val in dataset_specific_arguments.items():
+                if key not in kwargs:
+                    kwargs[key] = val
+        
+        # build model with arguments
         return model(**kwargs)
+
+    # otherwise return model constructor
     return model

--- a/networkAlignmentAnalysis/models/registry.py
+++ b/networkAlignmentAnalysis/models/registry.py
@@ -57,12 +57,8 @@ def get_model(model_name, build=False, dataset=None, **kwargs):
     model = MODEL_REGISTRY[model_name]
     if build:
         if dataset is not None:
-            if model_name not in DATASET_ARGUMENTS:
-                raise ValueError(f"Model ({model_name}) is not in DATASET_ARGUMENTS lookup dictionary.")
-            if dataset not in DATASET_ARGUMENTS[model_name]:
-                raise ValueError(f"Dataset ({dataset}) is not in the DATASET_ARGUMENTS lookup for model ({model_name})")
-            # get dataset specific arguments
-            dataset_specific_arguments = DATASET_ARGUMENTS[model_name][dataset]
+            # get default dataset specific arguments
+            dataset_specific_arguments = get_model_parameters(model_name, dataset)
 
             # for every dataset specific argument, if the key isn't provided in kwargs, 
             # then update it using the dataset_specific_arguments

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,107 @@
+import os
+import sys
+
+mainPath = os.path.dirname(os.path.abspath(__file__)) + "/.."
+sys.path.append(mainPath)
+
+import time
+from tqdm import tqdm
+
+import torch
+import torchvision 
+from torchvision import transforms
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+from networkAlignmentAnalysis import files
+
+DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
+    
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = torch.flatten(x, 1) # flatten all dimensions except batch
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+def check_time(num_workers, batch_size, pin_memory, fast_loader):
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+    trainset = torchvision.datasets.CIFAR10(root=files.data_path(), train=True,
+                                            download=False, transform=transform)
+
+    loader_kwargs = dict(
+        batch_size=batch_size,
+        shuffle=True, 
+        num_workers=num_workers,
+        pin_memory=pin_memory
+        )
+    
+    if fast_loader:
+        trainloader = torch.utils.data.DataLoader(trainset, **loader_kwargs, persistent_workers=fast_loader)
+    else:
+        trainloader = torch.utils.data.DataLoader(trainset, **loader_kwargs, persistent_workers=fast_loader)
+
+    net = Net()
+    net.to(DEVICE)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
+    time_per_batch = torch.zeros((2, len(trainloader)))
+    batch_time = time.time()
+    for cycle in range(2):
+        for idx, (images, labels) in enumerate(trainloader):
+            images, labels = images.to(DEVICE), labels.to(DEVICE)
+
+            optimizer.zero_grad()
+
+            outputs = net(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            
+            time_per_batch[cycle, idx] = time.time() - batch_time
+            batch_time = time.time()
+
+    avg_batch = torch.mean(time_per_batch[:, 1:])
+    total_time = torch.sum(time_per_batch)
+    init_time = time_per_batch[0, 0] - avg_batch # estimate of prepare time
+    second_init = time_per_batch[1, 0] - avg_batch
+    return init_time, avg_batch, total_time, second_init
+
+
+if __name__ == '__main__':
+    print('using device: ', DEVICE)
+
+    # tests
+    num_workers = [0, 2, 4]
+    batch_size = [8, 1024]
+    pin_memory = [True, False]
+    use_fast_loader = [True, False]
+
+    for nw in num_workers:
+        for bs in batch_size:
+            for pin in pin_memory:
+                for fast in use_fast_loader:
+                    if nw==0 and fast: continue # persistent memory is irrelevant when num_workers=0
+
+                    init, avg, total, second = check_time(nw, bs, pin, fast)
+                    print(f"NW={nw}, BS={bs}, Pin={pin}, Persistent={fast}")
+                    print(f"Dur={total:.3f}, PerBatch={avg:.2f}, Prep={init:.2f}, SecondPrep={second:.2f}")
+                    print('')

--- a/workspace.ipynb
+++ b/workspace.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -47,15 +47,14 @@
     "# TODO\n",
     "# 1.1. include additional AlignmentModel methods stored in extra class in base model\n",
     "\n",
-    "# I should also break apart the measure_eigenfeatures method for better parameter handling\n",
-    "# and also to allow use of components of the method in other contexts\n",
-    "\n",
     "# 4. Rewrite existing analysis pipelines\n",
     "# 5. SLURM!!!!\n",
     "\n",
     "# Figure out why convolutional alignment measurement is slow...\n",
     "\n",
-    "# 2. Make CIFAR class -- prioritize\n",
+    "# 2. Make CIFAR class -- prioritize --\n",
+    "# ----- this seems done... just need to adjust batch size and figure out normalization etcetera\n",
+    "# speed up loading... what the hell\n",
     "\n",
     "# Basic alignment_comparison Analyses (or maybe for alignment_stats):\n",
     "# - compare initial to final alignment...\n",
@@ -88,6 +87,48 @@
     "\n",
     "# still working on if it's possible to speed up measure_alignment for convolutional layers"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = get_dataset('CIFAR10', build=True, loader_parameters={'batch_size': 4})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([4, 3, 32, 32]) torch.Size([4])\n"
+     ]
+    }
+   ],
+   "source": [
+    "for idx, (images, labels) in enumerate(dataset.test_loader):\n",
+    "    print(images.shape, labels.shape)\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/workspace.ipynb
+++ b/workspace.ipynb
@@ -72,12 +72,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
-    "net = get_model('CNN2P2', build=True, each_stride=True).to(DEVICE)\n",
-    "dataset = get_dataset('MNIST', build=True, transform_parameters=net, device=DEVICE)\n",
+    "model_name = 'AlexNet'\n",
+    "dataset_name = 'MNIST'\n",
+    "\n",
+    "net = get_model(model_name, build=True, dataset=dataset_name, each_stride=True).to(DEVICE)\n",
+    "dataset = get_dataset(dataset_name, build=True, transform_parameters=net, device=DEVICE)\n",
     "\n",
     "batch = next(iter(dataset.test_loader))\n",
     "images, labels = dataset.unwrap_batch(batch)\n",
@@ -87,48 +90,6 @@
     "\n",
     "# still working on if it's possible to speed up measure_alignment for convolutional layers"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset = get_dataset('CIFAR10', build=True, loader_parameters={'batch_size': 4})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch.Size([4, 3, 32, 32]) torch.Size([4])\n"
-     ]
-    }
-   ],
-   "source": [
-    "for idx, (images, labels) in enumerate(dataset.test_loader):\n",
-    "    print(images.shape, labels.shape)\n",
-    "    break"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Now each model is loaded with the correct dataset-specific arguments (this works for the MLP, CNN2P2, and AlexNet on the datasets MNIST, CIFAR10, and CIFAR100).

The CNN2P2 model can be constructed in different ways depending on kwargs (e.g. the channels, kernel size, etc.). 

All 3 of those datasets are now established and registered in the dataset.py module.