### PR TITLE
Two small fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: networkAlignmentAnalysis
+name: alignment
 channels:
   - pytorch
   - nvidia

--- a/src/alignment/utils.py
+++ b/src/alignment/utils.py
@@ -211,6 +211,9 @@ def smart_pca(input, centered=True, use_rank=True, correction=True):
 
     _, D, S = input.size()
     if D > S:
+        # subtract mean if doing centered covariance
+        if centered:
+            input = input - input.mean(dim=2, keepdim=True)
         # if more dimensions than samples, it's more efficient to run svd
         v, w, _ = named_transpose([torch.linalg.svd(inp) for inp in input])
         # convert singular values to eigenvalues

--- a/src/alignment_v2/utils.py
+++ b/src/alignment_v2/utils.py
@@ -212,6 +212,9 @@ def smart_pca(input, centered=True, use_rank=True, correction=True):
 
     _, D, S = input.size()
     if D > S:
+        # subtract mean if doing centered pca
+        if centered:
+            input = input - input.mean(dim=2, keepdim=True)
         # if more dimensions than samples, it's more efficient to run svd
         v, w, _ = named_transpose([torch.linalg.svd(inp) for inp in input])
         # convert singular values to eigenvalues


### PR DESCRIPTION
## Change 1: Centering in smart_pca
smart_pca has two modes depending on whether the array is wider or taller. One uses ``batch_cov``, which implements centering by itself. The other uses ``torch.linalg.svd`` which doesn't center, so the ``smart_pca`` method is inconsistent. 

Sorry about this! That was definitely grandfathered in from my previous code. 

I just added a line to perform centering. 

## Change 2: Environment Name in the environment.yml
Also renamed the environment name in the env.yml to be consistent with the new repo name, but maybe this isn't even necessary given the use of the pyproject.toml? If it isn't necessary maybe we should delete the environment.yml file now? 
(There's a few inconsistencies though, like sklearn and natsort aren't included, is a different environment setup being used that I'm missing?)