### PR TITLE
Config looks for file paths in environment variables

### DIFF
--- a/configs/config_alignment_stats.yaml
+++ b/configs/config_alignment_stats.yaml
@@ -1,5 +1,5 @@
 experiment: alignment_stats
-results_path: # <-- Add path to where results to be saved/loaded
+results_path: ${oc.env:RESULTS_PATH,NOT_SET} # Add path to where results to be saved/loaded in your .env file
 no_save: False
 just_plot: False
 save_networks: False
@@ -11,7 +11,7 @@ use_timestamp: False
 
 dataset:
   name: MNIST
-  path: # <-- Add path to your dataset
+  path: ${oc.env:MNIST_PATH,NOT_SET} # Add path to your dataset in your .env file
   download: True # Downloads it if it does not exist.
 
 model:

--- a/src/alignment/config.py
+++ b/src/alignment/config.py
@@ -24,9 +24,28 @@ class BaseConfig:
         try:
             raw = om.load(str(path))
             conf = om.merge(schema, raw)
-            return cast(C, om.to_object(conf))
+            return cls._check_config(cast(C, om.to_object(conf)))
         except OmegaConfBaseException as e:
-            raise ValueError(str(e))
+            raise ValueError(str(e)) from e
+        
+    @classmethod
+    def _check_config(cls, cfg: C):
+        """Check that the config is valid. 
+        
+        Subclasses can override this method for additional checks. The standard checks are:
+        - results_path is set
+
+        - dataset.path is set
+
+        It is expected that these will be set as environment variables, e.g. RESULTS_PATH, MNIST_PATH etc
+        These can be set in a .env file in the root directory of the project. 
+        """
+        if hasattr(cfg, "results_path") and cfg.results_path == "NOT_SET":
+            raise ValueError("results_path is not set -- please make a .env file and set RESULTS_PATH to a valid path!")
+        if hasattr(cfg, "dataset") and hasattr(cfg.dataset, "path") and cfg.dataset.path == "NOT_SET":
+            dataset_name = cfg.dataset.name
+            raise ValueError(f"{dataset_name}.path is not set -- please make a .env file and set {dataset_name}_PATH to the local path of the dataset!")
+        return cfg
 
 @dataclass
 class ModelConfig(BaseConfig):


### PR DESCRIPTION
This is another suggestion -- I'm always skeptical of having files that differ across different installs on each computer. The config file as is requires a user to change the config locally to hardcode their filepaths to the results directory and to dataset paths. 

This PR provides a solution: omegaconf has a default resolver for environment variables, so we can just use a `.env` file in the root directory with ``RESULTS_PATH`` etc set by each user and then the config file can be the same across all copies of the code. 

Again, just a suggestion, if there's a better solution let me know.